### PR TITLE
fix: change mark as watched icon to eye icon

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PosterActionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PosterActionSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -34,7 +35,7 @@ fun NuvioWatchedBadge(
         contentAlignment = Alignment.Center,
     ) {
         Icon(
-            imageVector = Icons.Default.Check,
+            imageVector = Icons.Default.Visibility,
             contentDescription = stringResource(Res.string.episodes_cd_watched),
             tint = tokens.colors.onAccent,
             modifier = Modifier.size(NuvioTokens.Icon.xs),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -37,6 +37,8 @@ import androidx.compose.material.icons.filled.CheckCircleOutline
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.PlaylistAddCheckCircle
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import com.nuvio.app.core.ui.NuvioLoadingIndicator
@@ -2010,9 +2012,9 @@ private fun ConfiguredMetaSections(
                                 stringResource(Res.string.hero_mark_watched)
                             },
                             icon = if (isWatched) {
-                                Icons.Default.CheckCircle
+                                Icons.Default.Visibility
                             } else {
-                                Icons.Default.CheckCircleOutline
+                                Icons.Default.VisibilityOff
                             },
                             isActive = isWatched,
                             onClick = onWatchedClick,


### PR DESCRIPTION
## Description
Changed the watch status icon to use an eye icon instead of the checkmark to avoid ambiguity with the watchlist button.

## Screenshots

| Before | After |
| :---: | :---: |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/e97631d6-fe00-473d-a4e1-2856b3cda9d4" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/1ff217b6-0f6d-403e-8dff-ec608757e75d" /> |
| <img width="250"  alt="image" src="https://github.com/user-attachments/assets/576b154f-3642-4e40-8651-d37f9135cb0c" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/fc6444d1-17aa-4b17-bbd1-9628b120ed96" /> |
| <img width="220" alt="image" src="https://github.com/user-attachments/assets/3b4039f0-795f-4752-9f3a-3218f1f43c36" /> | <img width="220" alt="image" src="https://github.com/user-attachments/assets/eec58e54-bdc2-4ee5-9b9e-96366708e679" /> |


Closes #41