### PR TITLE
fix(profile): fix profile editor freeze and incorrect return screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/AppGate.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/AppGate.kt
@@ -151,6 +151,8 @@ internal fun AppGate(
 
     var gateScreen by rememberSaveable { mutableStateOf(AppGateScreen.Loading.name) }
     var editingProfile by remember { mutableStateOf<NuvioProfile?>(null) }
+    var profileEditReturnScreen by rememberSaveable { mutableStateOf(AppGateScreen.ProfileSelection.name) }
+    var pendingSettingsProfileReturn by rememberSaveable { mutableStateOf(false) }
     var autoSkipProfileSelection by rememberSaveable { mutableStateOf(false) }
     var profileSelectionLoading by rememberSaveable { mutableStateOf(false) }
     var profileSelectionTransitionActive by rememberSaveable { mutableStateOf(false) }
@@ -161,6 +163,13 @@ internal fun AppGate(
         ready
     } else {
         false
+    }
+
+    LaunchedEffect(profileSelectionTransitionActive) {
+        if (!profileSelectionTransitionActive) return@LaunchedEffect
+        kotlinx.coroutines.delay(20_000)
+        profileSelectionLoading = false
+        profileSelectionTransitionActive = false
     }
 
     LaunchedEffect(gateScreen, onAppReady) {
@@ -202,6 +211,7 @@ internal fun AppGate(
         if (renderMainContent) return@LaunchedEffect
         appGateController?.profileEditRequests?.collect {
             editingProfile = ProfileRepository.state.value.activeProfile
+            profileEditReturnScreen = AppGateScreen.Main.name
             gateScreen = AppGateScreen.ProfileEdit.name
         }
     }
@@ -234,6 +244,7 @@ internal fun AppGate(
     LaunchedEffect(externalMainContentReady, renderMainContent) {
         if (!renderMainContent && externalMainContentReady) {
             profileSelectionLoading = false
+            profileSelectionTransitionActive = false
         }
     }
 
@@ -414,12 +425,16 @@ internal fun AppGate(
                 !profileOverlayState.currentState &&
                 launchOverlayState.isIdle &&
                 !launchOverlayState.currentState
-        onAppReady?.invoke(
-            gateScreen == AppGateScreen.Main.name &&
-                externalMainContentReady &&
-                !profileSelectionLoading &&
-                overlaysHidden,
-        )
+        val ready = gateScreen == AppGateScreen.Main.name &&
+            externalMainContentReady &&
+            !profileSelectionLoading &&
+            overlaysHidden
+        onAppReady?.invoke(ready)
+        if (ready && pendingSettingsProfileReturn) {
+            pendingSettingsProfileReturn = false
+            appGateController?.requestSettingsPage("Profile")
+            onActivate?.invoke(AppScreenTab.Settings)
+        }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -453,13 +468,19 @@ internal fun AppGate(
                     )
                 }
                 AppGateScreen.ProfileEdit.name -> {
+                    val returnFromProfileEdit = {
+                        gateScreen = profileEditReturnScreen
+                        if (profileEditReturnScreen == AppGateScreen.Main.name) {
+                            pendingSettingsProfileReturn = true
+                        }
+                    }
                     PlatformBackHandler(enabled = gateScreen == AppGateScreen.ProfileEdit.name) {
-                        gateScreen = AppGateScreen.ProfileSelection.name
+                        returnFromProfileEdit()
                     }
                     ProfileEditScreen(
                         profile = editingProfile,
-                        onBack = { gateScreen = AppGateScreen.ProfileSelection.name },
-                        onSaved = { gateScreen = AppGateScreen.ProfileSelection.name },
+                        onBack = returnFromProfileEdit,
+                        onSaved = returnFromProfileEdit,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
@@ -482,6 +503,7 @@ internal fun AppGate(
                             onRootContentReady = { ready ->
                                 if (ready) {
                                     profileSelectionLoading = false
+                                    profileSelectionTransitionActive = false
                                 }
                                 onAppReady?.invoke(
                                     ready && gateScreen == AppGateScreen.Main.name,
@@ -497,6 +519,7 @@ internal fun AppGate(
                             onEditProfile = {
                                 editingProfile = profileState.activeProfile
                                 skipProfileSelectionEnterAnimation = false
+                                profileEditReturnScreen = AppGateScreen.Main.name
                                 gateScreen = AppGateScreen.ProfileEdit.name
                             },
                         )
@@ -557,11 +580,13 @@ internal fun AppGate(
                     onEditProfile = { profile ->
                         editingProfile = profile
                         skipProfileSelectionEnterAnimation = false
+                        profileEditReturnScreen = AppGateScreen.ProfileSelection.name
                         gateScreen = AppGateScreen.ProfileEdit.name
                     },
                     onAddProfile = {
                         editingProfile = null
                         skipProfileSelectionEnterAnimation = false
+                        profileEditReturnScreen = AppGateScreen.ProfileSelection.name
                         gateScreen = AppGateScreen.ProfileEdit.name
                     },
                     interactionEnabled = !profileSelectionLoading,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/AppGateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/AppGateController.kt
@@ -9,11 +9,13 @@ import kotlinx.coroutines.flow.update
 class AppGateController {
     private val profileSelectionChannel = Channel<Unit>(Channel.BUFFERED)
     private val profileEditChannel = Channel<Unit>(Channel.BUFFERED)
+    private val settingsPageChannel = Channel<String>(Channel.BUFFERED)
     private val _mainContentReady = MutableStateFlow(false)
     private val _contentGeneration = MutableStateFlow(0)
 
     internal val profileSelectionRequests = profileSelectionChannel.receiveAsFlow()
     internal val profileEditRequests = profileEditChannel.receiveAsFlow()
+    internal val settingsPageRequests = settingsPageChannel.receiveAsFlow()
     internal val mainContentReady = _mainContentReady.asStateFlow()
     internal val contentGeneration = _contentGeneration.asStateFlow()
 
@@ -23,6 +25,10 @@ class AppGateController {
 
     fun requestProfileEdit() {
         profileEditChannel.trySend(Unit)
+    }
+
+    internal fun requestSettingsPage(pageName: String) {
+        settingsPageChannel.trySend(pageName)
     }
 
     internal fun beginContentReload() {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
@@ -352,6 +352,14 @@ internal fun MainAppContent(
         }
     }
 
+    val isSettingsPageRequestOwner = !useNativeNavigation || initialTab == AppScreenTab.Settings
+    LaunchedEffect(appGateController, isSettingsPageRequestOwner) {
+        if (!isSettingsPageRequestOwner) return@LaunchedEffect
+        appGateController?.settingsPageRequests?.collect { pageName ->
+            requestedSettingsPageName = pageName
+        }
+    }
+
     fun handleRootTabClick(tab: AppScreenTab) {
         if (selectedTab != tab) {
             activateTab(tab)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/network/BackendRateLimit.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/network/BackendRateLimit.kt
@@ -99,7 +99,8 @@ internal fun retryAfterDelayMillis(
     } else {
         null
     }
-    return secondsDelay ?: dateDelay ?: fallbackDelayMs.coerceAtLeast(0L)
+    return (secondsDelay ?: dateDelay ?: fallbackDelayMs.coerceAtLeast(0L))
+        .coerceAtMost(MaximumFallbackDelayMs)
 }
 
 internal fun backendRetryDelayMillis(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/network/SupabaseProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/network/SupabaseProvider.kt
@@ -9,6 +9,7 @@ import io.github.jan.supabase.functions.Functions
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.storage.Storage
 import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.http.HttpHeaders
 import io.ktor.http.takeFrom
@@ -93,6 +94,10 @@ object SupabaseProvider {
                 }
                 defaultRequest {
                     headers.append(HttpHeaders.UserAgent, userAgent)
+                }
+                install(HttpTimeout) {
+                    requestTimeoutMillis = 30_000L
+                    connectTimeoutMillis = 15_000L
                 }
             }
             install(Auth)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/profiles/ProfileEditScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/profiles/ProfileEditScreen.kt
@@ -309,29 +309,32 @@ fun ProfileEditScreen(
                 onClick = {
                     isSaving = true
                     scope.launch {
-                        val avatarColorHex = visibleAvatarItem?.bgColor ?: fallbackColorHex
-                        if (isNew) {
-                            ProfileRepository.createProfile(
-                                name = name,
-                                avatarColorHex = avatarColorHex,
-                                avatarId = if (customAvatarUrl == null) selectedAvatarId else null,
-                                avatarUrl = customAvatarUrl,
-                                usesPrimaryAddons = usesPrimaryAddons,
-                            )
-                        } else {
-                            ProfileRepository.updateProfile(
-                                profileIndex = currentProfile!!.profileIndex,
-                                name = name,
-                                avatarColorHex = avatarColorHex,
-                                avatarId = if (customAvatarUrl == null) selectedAvatarId else null,
-                                avatarUrl = customAvatarUrl,
-                                profileBackgroundId = selectedBackgroundId,
-                                profileBackgroundUrl = selectedBackgroundUrl,
-                                usesPrimaryAddons = usesPrimaryAddons,
-                            )
+                        try {
+                            val avatarColorHex = visibleAvatarItem?.bgColor ?: fallbackColorHex
+                            if (isNew) {
+                                ProfileRepository.createProfile(
+                                    name = name,
+                                    avatarColorHex = avatarColorHex,
+                                    avatarId = if (customAvatarUrl == null) selectedAvatarId else null,
+                                    avatarUrl = customAvatarUrl,
+                                    usesPrimaryAddons = usesPrimaryAddons,
+                                )
+                            } else {
+                                ProfileRepository.updateProfile(
+                                    profileIndex = currentProfile!!.profileIndex,
+                                    name = name,
+                                    avatarColorHex = avatarColorHex,
+                                    avatarId = if (customAvatarUrl == null) selectedAvatarId else null,
+                                    avatarUrl = customAvatarUrl,
+                                    profileBackgroundId = selectedBackgroundId,
+                                    profileBackgroundUrl = selectedBackgroundUrl,
+                                    usesPrimaryAddons = usesPrimaryAddons,
+                                )
+                            }
+                            onSaved()
+                        } finally {
+                            isSaving = false
                         }
-                        isSaving = false
-                        onSaved()
                     }
                 },
             )


### PR DESCRIPTION
## Summary

- Cap the backend rate-limit retry delay and add an HTTP timeout to SupabaseProvider so a bad Retry-After response can no longer stall every request through the shared Supabase client indefinitely.
- Always clear isSaving via try/finally in ProfileEditScreen so a failed/hanging save can't leave the button stuck.
- Reset profileSelectionTransitionActive on every content-ready path in AppGate, plus a 20s safety-net timeout, so the full-screen loading overlay can never get stuck open permanently.
- Make Save and Back return to whichever screen opened the profile editor (Settings or the profile picker) instead of always jumping to the profile selector.
- Defer the native tab activation until the app is actually reported ready, and route the "open Settings page" request only to the Settings tab's own instance, so Save/Back deterministically land on Settings > Profile instead of Home or a race-dependent screen.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Editing a profile (Settings > Profile > Edit Profile) could permanently freeze the app on the full-screen Nuvio loading animation: a stray backend 429/503 response with a large `Retry-After` header stalled every subsequent request on the shared network client indefinitely, and separately a loading flag (`profileSelectionTransitionActive`) had no code path to reset once set while running with a native tab bar, so the loading overlay never dismissed. On top of that, both "Save changes" and the back button always routed back to the profile selector (or, after a partial fix, to the Home tab) instead of back to Settings > Profile where the user actually started.

## Issue or approval

Fixes #67

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

An unrelated Simulator-only build fix for `MetalLayer.swift` (a Metal API unavailable on the iOS Simulator's `CAMetalDrawable`) was intentionally split out into a separate branch/PR (`fix/simulator-metal-drawable-build`) since it addresses a different problem.


## Testing

- Built and ran the app (Debug, `appstore` distribution) on an iPhone 16 simulator (iOS 26.3) via `xcodebuild`.
- Reproduced the original freeze: Settings > Profile > Edit Profile > Save/Back got stuck on the loading animation.
- Verified the fix: edited the active profile from Settings > Profile, pressed Save — returns to Settings > Profile. Repeated entering via Back instead of Save — also returns to Settings > Profile, no freeze.
- Verified editing/adding a profile from the profile picker (manage profiles) still returns to the picker on Save/Back, unaffected by this change.

## Screenshots / Video

<video src="https://github.com/user-attachments/assets/74146e89-182d-4175-9913-df6737572dbe" controls width="480"></video>

## Breaking changes

None

## Linked issues

Fixes #67