### PR TITLE
feat(profile): custom background image URL for any account

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -8,6 +8,10 @@
     <string name="profile_background_member_note">Custom background URLs can be configured from the Nuvio web panel.</string>
     <string name="profile_background_normal">Normal</string>
     <string name="profile_background_custom">Custom</string>
+    <string name="profile_custom_background_url">Custom background URL</string>
+    <string name="profile_custom_background_url_description">Paste an image link to use as this profile\'s background, or leave this empty to use the default background.</string>
+    <string name="profile_custom_background_url_placeholder">https://example.com/background.jpg</string>
+    <string name="profile_background_url_invalid">Enter a valid http:// or https:// image URL.</string>
     <string name="about_licenses_attributions_subtitle">Data sources, acknowledgements, and platform licenses</string>
     <string name="about_supporters_contributors_subtitle">Open recognition and project credits</string>
     <string name="action_back">Back</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/membership/ProfileBackground.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/membership/ProfileBackground.kt
@@ -11,10 +11,10 @@ fun resolveProfileBackground(
     profile: NuvioProfile,
     entitlements: CosmeticEntitlements,
 ): ProfileBackgroundSelection? {
-    if (!entitlements.includes(CosmeticEntitlement.PROFILE_BACKGROUNDS)) return null
     profile.profileBackgroundUrl?.trim()?.takeIf { it.isNotBlank() }?.let {
         return ProfileBackgroundSelection.Custom(it)
     }
+    if (!entitlements.includes(CosmeticEntitlement.PROFILE_BACKGROUNDS)) return null
     profile.profileBackgroundId?.trim()?.takeIf { it.isNotBlank() }?.let {
         return ProfileBackgroundSelection.Catalog(it)
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/profiles/ProfileEditScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/profiles/ProfileEditScreen.kt
@@ -85,6 +85,7 @@ fun ProfileEditScreen(
     var avatarUrl by rememberSaveable { mutableStateOf(currentProfile?.avatarUrl.orEmpty()) }
     var selectedBackgroundId by rememberSaveable { mutableStateOf(currentProfile?.profileBackgroundId) }
     var selectedBackgroundUrl by rememberSaveable { mutableStateOf(currentProfile?.profileBackgroundUrl) }
+    var customBackgroundUrlInput by rememberSaveable { mutableStateOf(currentProfile?.profileBackgroundUrl.orEmpty()) }
     var usesPrimaryAddons by rememberSaveable { mutableStateOf(currentProfile?.usesPrimaryAddons ?: false) }
     var isSaving by remember { mutableStateOf(false) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
@@ -112,6 +113,8 @@ fun ProfileEditScreen(
 
     val customAvatarUrl = remember(avatarUrl) { normalizedAvatarUrl(avatarUrl) }
     val avatarUrlIsInvalid = avatarUrl.isNotBlank() && customAvatarUrl == null
+    val customBackgroundUrl = remember(customBackgroundUrlInput) { normalizedAvatarUrl(customBackgroundUrlInput) }
+    val customBackgroundUrlIsInvalid = customBackgroundUrlInput.isNotBlank() && customBackgroundUrl == null
     val selectedAvatarItem = remember(selectedAvatarId, avatars) {
         selectedAvatarId?.let { id -> avatars.find { it.id == id } }
     }
@@ -204,8 +207,50 @@ fun ProfileEditScreen(
                             onSelectionChange = { id, url ->
                                 selectedBackgroundId = id
                                 selectedBackgroundUrl = url
+                                customBackgroundUrlInput = ""
                             },
                         )
+                    }
+                }
+            }
+        }
+
+        if (!isNew) {
+            item {
+                NuvioSurfaceCard {
+                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Text(
+                            text = stringResource(Res.string.profile_custom_background_url),
+                            style = MaterialTheme.typography.titleLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        Text(
+                            text = stringResource(Res.string.profile_custom_background_url_description),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        NuvioInputField(
+                            value = customBackgroundUrlInput,
+                            onValueChange = { value ->
+                                customBackgroundUrlInput = value
+                                val normalized = normalizedAvatarUrl(value)
+                                if (normalized != null) {
+                                    selectedBackgroundId = null
+                                    selectedBackgroundUrl = normalized
+                                } else if (value.isBlank()) {
+                                    selectedBackgroundId = null
+                                    selectedBackgroundUrl = null
+                                }
+                            },
+                            placeholder = stringResource(Res.string.profile_custom_background_url_placeholder),
+                        )
+                        if (customBackgroundUrlIsInvalid) {
+                            Text(
+                                text = stringResource(Res.string.profile_background_url_invalid),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
                     }
                 }
             }
@@ -305,7 +350,7 @@ fun ProfileEditScreen(
                 } else {
                     stringResource(Res.string.collections_editor_save_changes)
                 },
-                enabled = name.isNotBlank() && !avatarUrlIsInvalid && !isSaving,
+                enabled = name.isNotBlank() && !avatarUrlIsInvalid && !customBackgroundUrlIsInvalid && !isSaving,
                 onClick = {
                     isSaving = true
                     scope.launch {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ProfileInsightsSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ProfileInsightsSettingsPage.kt
@@ -71,6 +71,7 @@ import com.nuvio.app.features.library.LibraryUiState
 import com.nuvio.app.features.profiles.AvatarCatalogItem
 import com.nuvio.app.features.profiles.AvatarRepository
 import com.nuvio.app.features.profiles.NuvioProfile
+import com.nuvio.app.features.profiles.ProfileBackgroundBackdrop
 import com.nuvio.app.features.profiles.ProfileRepository
 import com.nuvio.app.features.profiles.parseHexColor
 import com.nuvio.app.features.profiles.profileAvatarImageUrl
@@ -326,17 +327,28 @@ private fun ProfileInsightsHero(
         modifier = Modifier
             .fillMaxWidth()
             .clip(shape)
-            .background(
-                Brush.linearGradient(
-                    listOf(
-                        Color(0xFF0E1727),
-                        accent.copy(alpha = 0.42f),
-                        tokens.colors.surface,
-                    ),
-                ),
-            )
             .border(1.dp, Color.White.copy(alpha = 0.12f), shape),
     ) {
+        if (profile != null) {
+            ProfileBackgroundBackdrop(
+                profile = profile,
+                modifier = Modifier.matchParentSize(),
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(
+                        Brush.linearGradient(
+                            listOf(
+                                Color(0xFF0E1727),
+                                accent.copy(alpha = 0.42f),
+                                tokens.colors.surface,
+                            ),
+                        ),
+                    ),
+            )
+        }
         Box(
             modifier = Modifier
                 .matchParentSize()


### PR DESCRIPTION
## Summary

- Add a "Custom background URL" field to Edit Profile, separate from the membership-gated background catalog, so any account can set a direct image link as their profile background.
- Update `resolveProfileBackground` so a custom background URL always renders regardless of membership entitlements, while the curated catalog stays behind `CosmeticEntitlement.PROFILE_BACKGROUNDS`.
- Show the resolved background (custom or catalog) behind the Home > Profile stats header (`ProfileInsightsHero`) via `ProfileBackgroundBackdrop`, falling back to the existing gradient when no background is set.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

The predefined background catalog was the only way to personalize a profile's backdrop, and it's gated behind paid membership. This adds a free, always-available option: paste any image URL and use it as your profile background, without touching the paid catalog's gating.

## Issue or approval

Closes #65 

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change the paid background catalog's gating — catalog backgrounds still require `CosmeticEntitlement.PROFILE_BACKGROUNDS`.
- Does not add background support to profile *creation* — stays edit-only, matching the existing constraint (`createProfile` has no background parameters).
- New strings were only added to the base `values/strings.xml` (English); not translated to the ~22 other locales in the repo, since this is a personal-fork feature.

## Testing

- Built and ran on an iPhone 16 simulator (iOS 26.3) via `xcodebuild`.
- Set a custom background URL in Edit Profile and verified it renders in: Edit Profile's own preview, the Home > Profile stats header, and the profile selection/loading overlay screens.
- Confirmed catalog backgrounds still require membership, while the custom URL field works regardless of entitlement.
- Confirmed the field validates for `http://`/`https://` URLs and blocks "Save changes" when invalid.

## Screenshots / Video

<video src="https://github.com/user-attachments/assets/cf545a4b-a628-4e3c-902c-dff232618c99" controls width="480"></video>


## Breaking changes

None.

## Linked issues

Closes #65 