### PR TITLE
fix(ios): restore native morphed tab interaction

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -634,6 +634,7 @@ final class AppNavigationCoordinator: ObservableObject {
     @Published private(set) var isMainContentVisible = false
     @Published private(set) var isAppReady = false
     @Published private(set) var isTabBarVisible = true
+    @Published private(set) var isNativeTabBarVisible = true
     @Published private(set) var tabBarBehavior: NuvioTabBarBehavior = NuvioTabBarBehavior.current()
     @Published private(set) var isSelectedTabAtRoot = true
     @Published private(set) var isLiveTvTabVisible = false
@@ -641,6 +642,8 @@ final class AppNavigationCoordinator: ObservableObject {
     @Published private(set) var localizedSwitchProfileTitle = ""
     @Published private(set) var localizedAddProfileTitle = ""
     @Published var isProfileSwitcherPresented = false
+
+    private var tabBarTransitionTask: Task<Void, Never>?
 
     let homeCoordinator = TabNavigationCoordinator()
     let searchCoordinator = TabNavigationCoordinator()
@@ -694,12 +697,12 @@ final class AppNavigationCoordinator: ObservableObject {
     }
 
     func requestTabBarVisible(_ visible: Bool) {
-        setTabBarVisible(visible)
+        setTabBarVisible(visible, animated: tabBarBehavior == .morphed)
     }
 
     func reloadTabBarVisibility() {
         guard tabBarBehavior.respondsToScroll else {
-            if !isTabBarVisible { isTabBarVisible = true }
+            setTabBarVisible(true)
             return
         }
         guard let visible = UserDefaults.standard.object(
@@ -707,15 +710,41 @@ final class AppNavigationCoordinator: ObservableObject {
         ) as? Bool else {
             return
         }
-        if isTabBarVisible != visible {
-            isTabBarVisible = visible
-        }
+        setTabBarVisible(visible, animated: tabBarBehavior == .morphed)
     }
 
-    private func setTabBarVisible(_ visible: Bool) {
+    private func setTabBarVisible(_ visible: Bool, animated: Bool = false) {
         UserDefaults.standard.set(visible, forKey: Self.nativeTabBarVisibleKey)
-        if isTabBarVisible != visible {
+        tabBarTransitionTask?.cancel()
+        tabBarTransitionTask = nil
+
+        guard animated else {
             isTabBarVisible = visible
+            isNativeTabBarVisible = visible
+            return
+        }
+
+        if visible {
+            guard !isTabBarVisible || !isNativeTabBarVisible else { return }
+            withAnimation(.smooth(duration: 0.38)) {
+                isTabBarVisible = visible
+            }
+            guard !isNativeTabBarVisible else { return }
+
+            tabBarTransitionTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 340_000_000)
+                guard !Task.isCancelled, let self, self.isTabBarVisible else { return }
+                withAnimation(.easeOut(duration: 0.04)) {
+                    self.isNativeTabBarVisible = true
+                }
+            }
+            return
+        }
+
+        guard isTabBarVisible || isNativeTabBarVisible else { return }
+        withAnimation(.smooth(duration: 0.38)) {
+            isNativeTabBarVisible = false
+            isTabBarVisible = false
         }
     }
 
@@ -1003,15 +1032,19 @@ struct TabContentView: View {
         // full-screen on iOS 26, where a modifier on TabView itself is ignored.
         .toolbar(
             usesNativeTabBar &&
-                !appCoordinator.tabBarBehavior.usesCustomBar &&
                 appCoordinator.isMainContentVisible &&
                 coordinator.path.isEmpty &&
-                appCoordinator.isTabBarVisible
+                appCoordinator.isNativeTabBarVisible
                 ? Visibility.visible
                 : Visibility.hidden,
             for: .tabBar
         )
-        .animation(.easeInOut(duration: 0.18), value: appCoordinator.isTabBarVisible)
+        .animation(
+            appCoordinator.tabBarBehavior == .autoHide
+                ? .easeInOut(duration: 0.18)
+                : nil,
+            value: appCoordinator.isNativeTabBarVisible
+        )
     }
 }
 
@@ -1505,19 +1538,19 @@ struct NativeNavContentView: View {
         }
         .tint(Color(uiColor: iconStore.accentColor))
         .tabBarMinimizeBehavior(
-            appCoordinator.tabBarBehavior.respondsToScroll ? .onScrollDown : .never
+            appCoordinator.tabBarBehavior == .autoHide ? .onScrollDown : .never
         )
         .overlay(alignment: .bottom) {
-            if appCoordinator.tabBarBehavior.usesCustomBar &&
+            if appCoordinator.tabBarBehavior.usesCompactPill &&
                 appCoordinator.isAppReady &&
                 appCoordinator.isSelectedTabAtRoot {
                 NuvioGlassTabBar(
                     appCoordinator: appCoordinator,
-                    iconStore: iconStore,
-                    selection: tabSelection
+                    iconStore: iconStore
                 )
-                .padding(.horizontal, 16)
-                .transition(.opacity)
+                .padding(.horizontal, appCoordinator.isTabBarVisible ? 20 : 16)
+                .opacity(appCoordinator.isNativeTabBarVisible ? 0 : 1)
+                .accessibilityHidden(appCoordinator.isNativeTabBarVisible)
             }
         }
         .ignoresSafeArea(.container, edges: .bottom)

--- a/iosApp/iosApp/NuvioGlassTabBar.swift
+++ b/iosApp/iosApp/NuvioGlassTabBar.swift
@@ -16,64 +16,30 @@ enum NuvioTabBarBehavior: String, CaseIterable {
 
     var isEnabled: Bool { self != .off }
 
-    var usesCustomBar: Bool { self == .morphed }
+    var usesCompactPill: Bool { self == .morphed }
 
     var respondsToScroll: Bool { self == .autoHide || self == .morphed }
-}
-
-private struct TabBarItemFrame: Equatable {
-    let tab: NuvioAppTab
-    let rect: CGRect
-}
-
-private struct TabBarItemFramePreferenceKey: PreferenceKey {
-    static var defaultValue: [TabBarItemFrame] = []
-
-    static func reduce(value: inout [TabBarItemFrame], nextValue: () -> [TabBarItemFrame]) {
-        value.append(contentsOf: nextValue())
-    }
 }
 
 @available(iOS 26.0, *)
 struct NuvioGlassTabBar: View {
     @ObservedObject var appCoordinator: AppNavigationCoordinator
     @ObservedObject var iconStore: NativeTabIconStore
-    let selection: Binding<NuvioAppTab>
 
-    @State private var tabItemFrames: [NuvioAppTab: CGRect] = [:]
-    @State private var dragSourceTab: NuvioAppTab? = nil
-    @State private var dragTargetTab: NuvioAppTab? = nil
-    @State private var isDragging: Bool = false
-    @State private var dragTransitionToken = UUID()
     @Namespace private var glassNamespace
     @Environment(\.verticalSizeClass) private var verticalSizeClass
 
-    @State private var selectionFeedback = UISelectionFeedbackGenerator()
-    @State private var impactFeedback = UIImpactFeedbackGenerator(style: .medium)
-
     private static let barGlassID = "nuvio.tabbar"
-    private static let pillUnionID = "nuvio.tabbar.pillUnion"
-
-    private static let barHorizontalPadding: CGFloat = 6
-    private static let barVerticalPadding: CGFloat = 5
-
-    private static let liquidSpring: Animation = .interpolatingSpring(
-        mass: 1.0, stiffness: 260, damping: 26, initialVelocity: 0
-    )
-
-    private static let bridgeHeightMultiplier: CGFloat = 1.35
-    private static let bridgeCollapseDelay: TimeInterval = 0.22
-    private static let bridgeOverlap: CGFloat = 18
 
     static let portraitBottomInset: CGFloat = 20
     static let landscapeBottomInset: CGFloat = 16
 
-    var bottomInset: CGFloat {
-        isCompactLayout ? Self.landscapeBottomInset : Self.portraitBottomInset
+    private var bottomInset: CGFloat {
+        verticalSizeClass == .compact ? Self.landscapeBottomInset : Self.portraitBottomInset
     }
 
-    private var isCompactLayout: Bool {
-        verticalSizeClass == .compact
+    private var selectedTab: NuvioAppTab {
+        appCoordinator.selectedTab
     }
 
     private var isExpanded: Bool {
@@ -81,129 +47,34 @@ struct NuvioGlassTabBar: View {
     }
 
     private var visibleTabs: [NuvioAppTab] {
-        isExpanded ? appCoordinator.availableTabs : [appCoordinator.selectedTab]
-    }
-
-    private var activeDragSelection: NuvioAppTab? {
-        dragTargetTab
-    }
-
-    private var highlightedTab: NuvioAppTab? {
-        activeDragSelection ?? appCoordinator.selectedTab
-    }
-
-    private var isBridging: Bool {
-        isDragging &&
-        dragSourceTab != nil &&
-        dragTargetTab != nil &&
-        dragSourceTab != dragTargetTab
-    }
-
-    @ViewBuilder
-    private func glassPill(frame: CGRect, tinted: Bool) -> some View {
-        let heightMultiplier = isBridging ? Self.bridgeHeightMultiplier : 1.0
-
-        Capsule()
-            .fill(tinted ? Color(uiColor: iconStore.accentColor).opacity(0.12) : Color.white.opacity(0.001))
-            .glassEffect(.regular.interactive(), in: Capsule())
-            .frame(width: frame.width, height: frame.height)
-            .scaleEffect(x: 1, y: heightMultiplier, anchor: .center)
-            .offset(x: frame.minX, y: frame.minY)
-            .glassEffectUnion(id: Self.pillUnionID, namespace: glassNamespace)
-    }
-
-    @ViewBuilder
-    private var settledPill: some View {
-        if !isBridging,
-           let tab = (isDragging ? dragTargetTab : nil) ?? highlightedTab,
-           let frame = tabItemFrames[tab] {
-            glassPill(frame: frame, tinted: true)
-        }
-    }
-
-    private func translatedToOuterLayer(_ frame: CGRect) -> CGRect {
-        CGRect(
-            x: frame.minX + Self.barHorizontalPadding,
-            y: frame.minY + Self.barVerticalPadding,
-            width: frame.width,
-            height: frame.height
-        )
-    }
-
-    private func extendedTowards(_ frame: CGRect, other: CGRect, by amount: CGFloat) -> CGRect {
-        if other.midX >= frame.midX {
-            return CGRect(x: frame.minX, y: frame.minY, width: frame.width + amount, height: frame.height)
-        } else {
-            return CGRect(x: frame.minX - amount, y: frame.minY, width: frame.width + amount, height: frame.height)
-        }
+        isExpanded ? appCoordinator.availableTabs : [selectedTab]
     }
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            GlassEffectContainer(spacing: 0) {
-                HStack(spacing: 0) {
-                    ForEach(visibleTabs, id: \.self) { tab in
-                        item(for: tab)
-                    }
+        GlassEffectContainer(spacing: 0) {
+            HStack(spacing: 0) {
+                ForEach(visibleTabs, id: \.self) { tab in
+                    item(for: tab)
                 }
-                .coordinateSpace(name: "tabBar")
-                .background(alignment: .topLeading) {
-                    if isExpanded {
-                        settledPill
-                    }
-                }
-                .onPreferenceChange(TabBarItemFramePreferenceKey.self) { values in
-                    let newFrames = Dictionary(values.map { ($0.tab, $0.rect) }, uniquingKeysWith: { $1 })
-                    if tabItemFrames.isEmpty {
-                        var transaction = Transaction()
-                        transaction.disablesAnimations = true
-                        withTransaction(transaction) {
-                            tabItemFrames = newFrames
-                        }
-                    } else {
-                        tabItemFrames = newFrames
-                    }
-                }
-                .contentShape(Rectangle())
-                .highPriorityGesture(dragSelectionGesture(), including: .all)
-                .padding(.horizontal, Self.barHorizontalPadding)
-                .padding(.vertical, Self.barVerticalPadding)
-                .glassEffect(.clear.interactive(), in: Capsule())
-                .glassEffectID(Self.barGlassID, in: glassNamespace)
             }
-
-            if isExpanded, isBridging,
-               let source = dragSourceTab, let target = dragTargetTab,
-               let sourceFrame = tabItemFrames[source], let targetFrame = tabItemFrames[target] {
-                let extendedSource = extendedTowards(sourceFrame, other: targetFrame, by: Self.bridgeOverlap)
-                let extendedTarget = extendedTowards(targetFrame, other: sourceFrame, by: Self.bridgeOverlap)
-                GlassEffectContainer(spacing: 0) {
-                    glassPill(frame: translatedToOuterLayer(extendedSource), tinted: false)
-                    glassPill(frame: translatedToOuterLayer(extendedTarget), tinted: false)
-                }
-                .allowsHitTesting(false)
-            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, isExpanded ? 3 : 5)
+            .glassEffect(.clear.interactive(), in: Capsule())
+            .glassEffectID(Self.barGlassID, in: glassNamespace)
         }
         .frame(maxWidth: .infinity, alignment: isExpanded ? .center : .leading)
         .padding(.bottom, bottomInset)
         .ignoresSafeArea(.container, edges: .bottom)
-        .animation(Self.liquidSpring, value: dragSourceTab)
-        .animation(Self.liquidSpring, value: dragTargetTab)
-        .animation(Self.liquidSpring, value: isBridging)
-        .animation(Self.liquidSpring, value: tabItemFrames)
+        .allowsHitTesting(!isExpanded)
+        .accessibilityHidden(isExpanded)
         .animation(.smooth(duration: 0.38), value: isExpanded)
-        .animation(.smooth(duration: 0.26), value: appCoordinator.selectedTab)
-        .onAppear {
-            impactFeedback.prepare()
-        }
+        .animation(.smooth(duration: 0.26), value: selectedTab)
     }
 
-    @ViewBuilder
     private func item(for tab: NuvioAppTab) -> some View {
-        let selected = tab == appCoordinator.selectedTab
-        let isDragCandidate = tab == activeDragSelection
+        let selected = tab == selectedTab
         let content = Group {
-            if isCompactLayout {
+            if verticalSizeClass == .compact {
                 HStack(spacing: 6) {
                     icon(for: tab, selected: selected)
                     if isExpanded {
@@ -219,23 +90,20 @@ struct NuvioGlassTabBar: View {
                 }
             }
         }
-        .padding(.vertical, isCompactLayout ? 6 : 7)
-        .padding(.horizontal, isCompactLayout ? 12 : (isExpanded ? 4 : 10))
-        .frame(maxWidth: (isExpanded && !isCompactLayout) ? .infinity : nil)
+        .padding(.vertical, verticalSizeClass == .compact ? 6 : 7)
+        .padding(.horizontal, verticalSizeClass == .compact ? 12 : (isExpanded ? 4 : 10))
+        .frame(maxWidth: isExpanded && verticalSizeClass != .compact ? .infinity : nil)
         .contentShape(Capsule())
-        .scaleEffect(isDragCandidate ? 1.05 : 1.0)
-        .animation(Self.liquidSpring, value: isDragCandidate)
-        .background(
-            GeometryReader { proxy in
-                Color.clear.preference(
-                    key: TabBarItemFramePreferenceKey.self,
-                    value: [TabBarItemFrame(tab: tab, rect: proxy.frame(in: .named("tabBar")))]
-                )
+        .background {
+            if selected && isExpanded {
+                Capsule()
+                    .fill(Color(uiColor: iconStore.accentColor).opacity(0.12))
+                    .glassEffect(.regular, in: Capsule())
             }
-        )
+        }
 
         let button = Button {
-            handleTap(on: tab)
+            appCoordinator.requestTabBarVisible(true)
         } label: {
             content
         }
@@ -243,17 +111,18 @@ struct NuvioGlassTabBar: View {
         .accessibilityLabel(Text(appCoordinator.title(for: tab)))
         .accessibilityAddTraits(selected ? [.isSelected] : [])
 
-        if tab == .settings {
-            button.simultaneousGesture(
-                LongPressGesture(minimumDuration: 0.45)
-                    .onEnded { _ in
-                        guard appCoordinator.isAppReady else { return }
-                        impactFeedback.impactOccurred()
-                        appCoordinator.isProfileSwitcherPresented = true
-                    }
-            )
-        } else {
-            button
+        return Group {
+            if tab == .settings {
+                button.simultaneousGesture(
+                    LongPressGesture(minimumDuration: 0.45)
+                        .onEnded { _ in
+                            guard appCoordinator.isAppReady else { return }
+                            appCoordinator.isProfileSwitcherPresented = true
+                        }
+                )
+            } else {
+                button
+            }
         }
     }
 
@@ -293,66 +162,6 @@ struct NuvioGlassTabBar: View {
         }
         .frame(width: 24, height: 24)
         .legibleOverGlass(enabled: !selected)
-    }
-
-    private func handleTap(on tab: NuvioAppTab) {
-        guard isExpanded else {
-            appCoordinator.requestTabBarVisible(true)
-            return
-        }
-        selection.wrappedValue = tab
-    }
-
-    private func dragSelectionGesture() -> some Gesture {
-        DragGesture(minimumDistance: 2, coordinateSpace: .named("tabBar"))
-            .onChanged { value in
-                guard isExpanded else { return }
-                let location = value.location
-                guard let matchedTab = tabItemFrames.first(where: { $0.value.contains(location) })?.key else { return }
-
-                if !isDragging {
-                    selectionFeedback.prepare()
-                    isDragging = true
-                    dragSourceTab = appCoordinator.selectedTab
-                    dragTargetTab = matchedTab
-                    if matchedTab != appCoordinator.selectedTab {
-                        selectionFeedback.selectionChanged()
-                        scheduleBridgeCollapse(landingOn: matchedTab)
-                    }
-                    return
-                }
-
-                guard matchedTab != dragTargetTab else { return }
-
-                selectionFeedback.selectionChanged()
-                selectionFeedback.prepare()
-                dragSourceTab = dragTargetTab
-                dragTargetTab = matchedTab
-                scheduleBridgeCollapse(landingOn: matchedTab)
-            }
-            .onEnded { value in
-                guard isExpanded else { return }
-                if let tab = dragTargetTab {
-                    selection.wrappedValue = tab
-                }
-
-                withAnimation(Self.liquidSpring) {
-                    isDragging = false
-                    dragSourceTab = nil
-                    dragTargetTab = nil
-                }
-            }
-    }
-
-    private func scheduleBridgeCollapse(landingOn tab: NuvioAppTab) {
-        let token = UUID()
-        dragTransitionToken = token
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.bridgeCollapseDelay) {
-            guard dragTransitionToken == token, isDragging, dragTargetTab == tab else { return }
-            withAnimation(Self.liquidSpring) {
-                dragSourceTab = tab
-            }
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

On iOS, Morphed mode now leaves expanded tab switching to the native tab bar. The custom glass view only handles the compact pill and the transition into it. This keeps the morph animation while fixing the sticky drag, black flash, and delayed tab changes.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Morphed mode used a custom drag recognizer while the full tab bar was visible. It tried to copy the system Liquid Glass interaction, but dragging between tabs could make the bar stick, flash black, or change tabs late.

The expanded state now uses the native iOS tab bar. Scrolling down still morphs it into the selected-tab pill. Tapping the pill or scrolling up brings the full native bar back.

## Issue or approval

Related to #43. The problem came from the custom Morphed tab switching added in #48. Profile long-press still goes through the native tab bar coordinator.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This only changes the iOS Morphed tab bar. Static, Auto Hide, Off, iPad behavior, navigation depth, and tab contents are unchanged. No dependencies were added.

## Testing

- Built an unsigned Release IPA with Xcode 26.6 in [Actions run 33127295814](https://github.com/AradByte/NuvioMobile-Enhanced/actions/runs/33127295814).
- Tested native tapping and dragging across tabs while Morphed mode is expanded.
- Tested collapsing the bar by scrolling down, then expanding it by tapping the pill or scrolling up.
- Ran `git diff --check` on the PR commit.

## Screenshots / Video (UI changes only)

### Before

https://github.com/user-attachments/assets/feeefd87-8bcc-45b8-adb8-40a84e1260a1

The custom Morphed tab bar sticks and flashes black while moving between tabs.

### After

https://github.com/user-attachments/assets/688eb5b0-5a83-47c5-aef9-d097c4a4310d

The native tab bar handles tab switching, while the bar still morphs into the compact pill.

## Breaking changes

None.

## Linked issues

Related to #43. Regression introduced by #48.

